### PR TITLE
Fix broken import in README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Setup authentication by generating an API key and exporting it as the value of t
 
 ### Connect to API
 ```
-import poseidon.api as po
-client = po.connect() # or po.connect(api_key=<KEY>) for custom api key
+import poseidon
+client = poseidon.connect() # or poseidon.connect(api_key=<KEY>) for custom api key
 ```
 
 ### Create a droplet


### PR DESCRIPTION
The README tells you to import the `api` module and use that to connect to Digital Ocean. You need to import the entire `poseidon` module or you'll get an `AttributeError` since the `connect()` method doesn't exist.
