### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ poseidon
 
 Python library for managing your Digital Ocean account via API v2
 
-[![PyPi version](https://pypip.in/v/poseidon/badge.png)](https://crate.io/packages/poseidon/)
-[![PyPi downloads](https://pypip.in/d/poseidon/badge.png)](https://crate.io/packages/poseidon/)
+[![PyPi version](https://img.shields.io/pypi/v/poseidon.svg)](https://crate.io/packages/poseidon/)
+[![PyPi downloads](https://img.shields.io/pypi/dm/poseidon.svg)](https://crate.io/packages/poseidon/)
 
 The DigitalOcean API allows you to manage Droplets and resources within the
 DigitalOcean cloud in a simple, programmatic way using conventional HTTP


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20poseidon))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `poseidon`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.